### PR TITLE
include config files

### DIFF
--- a/src/highfive-server/highfive-server.xproj
+++ b/src/highfive-server/highfive-server.xproj
@@ -16,4 +16,8 @@
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ItemGroup>
+    <Content Include="Config/appsettings.json" />
+    <Content Include="Config/appsettings.Production.json" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
app would fail to run when deployed because at runtime was trying to read appsettings*json files from Config directory, however those files were not set to be included and published